### PR TITLE
Add camera screen navigation

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,5 +1,6 @@
 import { Image } from 'expo-image';
 import { Platform, StyleSheet } from 'react-native';
+import { Link } from 'expo-router';
 
 import { HelloWave } from '@/components/HelloWave';
 import ParallaxScrollView from '@/components/ParallaxScrollView';
@@ -20,6 +21,9 @@ export default function HomeScreen() {
         <ThemedText type="title">Welcome!</ThemedText>
         <HelloWave />
       </ThemedView>
+      <Link href="/camera" style={styles.link}>
+        <ThemedText type="link">Open Camera</ThemedText>
+      </Link>
       <ThemedView style={styles.stepContainer}>
         <ThemedText type="subtitle">Step 1: Try it</ThemedText>
         <ThemedText>
@@ -64,6 +68,9 @@ const styles = StyleSheet.create({
   stepContainer: {
     gap: 8,
     marginBottom: 8,
+  },
+  link: {
+    marginBottom: 16,
   },
   reactLogo: {
     height: 178,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,6 +21,7 @@ export default function RootLayout() {
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="camera" />
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style="auto" />

--- a/app/camera.tsx
+++ b/app/camera.tsx
@@ -1,0 +1,21 @@
+import { Stack } from 'expo-router';
+import { StyleSheet, View, Text } from 'react-native';
+
+export default function CameraScreen() {
+  return (
+    <>
+      <Stack.Screen options={{ title: 'Camera' }} />
+      <View style={styles.container}>
+        <Text>Camera Screen</Text>
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",
+    "@react-navigation/native-stack": "^7.3.16",
     "expo": "~53.0.11",
     "expo-blur": "~14.1.5",
     "expo-constants": "~17.1.6",


### PR DESCRIPTION
## Summary
- add camera screen with a basic layout
- show new screen in the stack navigation
- link to Camera from Home
- include @react-navigation/native-stack as dependency

## Testing
- `yarn lint` *(fails: Request was cancelled)*
- `npx expo --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6851678d9204832687dffd69aa49c047