### PR TITLE
Implement basic camera and Firebase auth

### DIFF
--- a/app/camera.tsx
+++ b/app/camera.tsx
@@ -1,24 +1,53 @@
 import { Stack, router } from 'expo-router';
-import { Button, StyleSheet, Text, View } from 'react-native';
-import { useCameraPermissions } from 'expo-camera';
+import { ActivityIndicator, Button, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Camera, CameraType, useCameraPermissions } from 'expo-camera';
+import { useRef, useState } from 'react';
+import { Ionicons } from '@expo/vector-icons';
 
 export default function CameraScreen() {
   const [permission, requestPermission] = useCameraPermissions();
+  const cameraRef = useRef<Camera>(null);
+  const [loading, setLoading] = useState(false);
+
+  const capture = async () => {
+    if (!cameraRef.current) return;
+    const photo = await cameraRef.current.takePictureAsync({ base64: true });
+    setLoading(true);
+    try {
+      const response = await fetch('https://example.com/api', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ image: photo.base64 }),
+      });
+      const data = await response.json();
+      router.push({ pathname: '/result', params: { text: data.text } });
+    } catch (e) {
+      console.warn(e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!permission) {
+    return <View style={styles.container}><Button title="Request Permission" onPress={requestPermission} /></View>;
+  }
+
+  if (!permission.granted) {
+    return <View style={styles.container}><Button title="Request Permission" onPress={requestPermission} /></View>;
+  }
 
   return (
-    <>
+    <View style={{ flex: 1 }}>
       <Stack.Screen options={{ title: 'Camera' }} />
-      <View style={styles.container}>
-        {permission?.granted ? (
-          <>
-            <Text>Camera Screen</Text>
-            <Button title="Show Result" onPress={() => router.push('/result')} />
-          </>
+      <Camera style={{ flex: 1 }} type={CameraType.back} ref={cameraRef} />
+      <TouchableOpacity style={styles.capture} onPress={capture} disabled={loading}>
+        {loading ? (
+          <ActivityIndicator color="#fff" size="large" />
         ) : (
-          <Button title="Request Permission" onPress={requestPermission} />
+          <Ionicons name="camera" size={64} color="white" />
         )}
-      </View>
-    </>
+      </TouchableOpacity>
+    </View>
   );
 }
 
@@ -27,5 +56,10 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  capture: {
+    position: 'absolute',
+    bottom: 40,
+    alignSelf: 'center',
   },
 });

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -1,30 +1,44 @@
-import { Alert, Button, StyleSheet, View } from 'react-native';
+import { Alert, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { Stack, router } from 'expo-router';
 import * as Camera from 'expo-camera';
-
-async function providerLogin(provider: string) {
-  // TODO: integrate with real authentication providers
-  console.log(`Login with ${provider}`);
-}
+import * as Google from 'expo-auth-session/providers/google';
+import { useEffect } from 'react';
+import { FontAwesome } from '@expo/vector-icons';
+import { GoogleAuthProvider, signInWithCredential } from 'firebase/auth';
+import { auth } from '@/firebase';
 
 export default function LoginScreen() {
-  const handleLogin = async (provider: string) => {
-    await providerLogin(provider);
-    const { status } = await Camera.requestCameraPermissionsAsync();
-    if (status === 'granted') {
-      router.replace('/camera');
-    } else {
-      Alert.alert('Permission required', 'Camera permission is required to continue.');
+  const [request, response, promptAsync] = Google.useAuthRequest({
+    expoClientId: 'GOOGLE_EXPO_CLIENT_ID',
+    iosClientId: 'GOOGLE_IOS_CLIENT_ID',
+    androidClientId: 'GOOGLE_ANDROID_CLIENT_ID',
+    webClientId: 'GOOGLE_WEB_CLIENT_ID',
+  });
+
+  useEffect(() => {
+    if (response?.type === 'success') {
+      const { id_token } = response.params;
+      const credential = GoogleAuthProvider.credential(id_token);
+      signInWithCredential(auth, credential)
+        .then(async () => {
+          const { status } = await Camera.requestCameraPermissionsAsync();
+          if (status === 'granted') {
+            router.replace('/camera');
+          } else {
+            Alert.alert('Permission required', 'Camera permission is required to continue.');
+          }
+        })
+        .catch((err) => console.warn(err));
     }
-  };
+  }, [response]);
 
   return (
     <>
       <Stack.Screen options={{ title: 'Login' }} />
       <View style={styles.container}>
-        <Button title="Login with Kakao" onPress={() => handleLogin('kakao')} />
-        <Button title="Login with Naver" onPress={() => handleLogin('naver')} />
-        <Button title="Login with Google" onPress={() => handleLogin('google')} />
+        <TouchableOpacity disabled={!request} onPress={() => promptAsync()}>
+          <FontAwesome name="google" size={64} color="#DB4437" />
+        </TouchableOpacity>
       </View>
     </>
   );

--- a/app/result.tsx
+++ b/app/result.tsx
@@ -1,18 +1,30 @@
-import { Button, StyleSheet, Text, View } from 'react-native';
-import { Stack, router } from 'expo-router';
+import { Animated, StyleSheet, View } from 'react-native';
+import { Stack, useLocalSearchParams } from 'expo-router';
+import { useEffect, useRef } from 'react';
 
 export default function ResultScreen() {
+  const { text } = useLocalSearchParams<{ text: string }>();
+  const opacity = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.timing(opacity, {
+      toValue: 1,
+      duration: 1000,
+      useNativeDriver: true,
+    }).start();
+  }, []);
+
   return (
     <>
       <Stack.Screen options={{ title: 'Result' }} />
       <View style={styles.container}>
-        <Text>Result Screen</Text>
-        <Button title="Back to Camera" onPress={() => router.replace('/camera')} />
+        <Animated.Text style={[styles.text, { opacity }]}>{text}</Animated.Text>
       </View>
     </>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 12 },
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  text: { fontSize: 24, textAlign: 'center' },
 });

--- a/firebase.ts
+++ b/firebase.ts
@@ -1,0 +1,12 @@
+import { initializeApp, getApps } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+
+const firebaseConfig = {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'YOUR_AUTH_DOMAIN',
+  projectId: 'YOUR_PROJECT_ID',
+  appId: 'YOUR_APP_ID',
+};
+
+export const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
+export const auth = getAuth(app);

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "firebase": "^9.23.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- add Firebase config placeholder
- add Google-based login using Firebase and show icon-only button
- capture photo, call API, and show text response with animation
- animate results text on result screen

## Testing
- `npm test` *(fails: Missing script)*
- `yarn lint` *(fails: network access needed to download yarn)*

------
https://chatgpt.com/codex/tasks/task_e_68533a1825f0832695398169bed78a36