### PR TITLE
Add sharing and animated result

### DIFF
--- a/app/result.tsx
+++ b/app/result.tsx
@@ -1,24 +1,40 @@
-import { Animated, StyleSheet, View } from 'react-native';
+import { Animated, Button, Share, StyleSheet, View } from 'react-native';
 import { Stack, useLocalSearchParams } from 'expo-router';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 export default function ResultScreen() {
   const { text } = useLocalSearchParams<{ text: string }>();
   const opacity = useRef(new Animated.Value(0)).current;
+  const translateY = useRef(new Animated.Value(20)).current;
+
+  const onShare = useCallback(() => {
+    Share.share({ message: text ?? '' }).catch((err) => console.warn(err));
+  }, [text]);
 
   useEffect(() => {
-    Animated.timing(opacity, {
-      toValue: 1,
-      duration: 1000,
-      useNativeDriver: true,
-    }).start();
+    Animated.parallel([
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: 1000,
+        useNativeDriver: true,
+      }),
+      Animated.spring(translateY, {
+        toValue: 0,
+        useNativeDriver: true,
+      }),
+    ]).start();
   }, []);
 
   return (
     <>
       <Stack.Screen options={{ title: 'Result' }} />
       <View style={styles.container}>
-        <Animated.Text style={[styles.text, { opacity }]}>{text}</Animated.Text>
+        <Animated.Text
+          style={[styles.text, { opacity, transform: [{ translateY }] }]}
+        >
+          {text}
+        </Animated.Text>
+        <Button title="Share" onPress={onShare} />
       </View>
     </>
   );


### PR DESCRIPTION
## Summary
- add share feature to result screen
- enhance poem display with slide-in animation

## Testing
- `yarn lint` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn)*
- `npm run lint` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856922ec0a08326881f7a1ca877955e