### PR TITLE
Skip login screen for camera testing

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,7 +21,8 @@ export default function RootLayout() {
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack initialRouteName="splash">
         <Stack.Screen name="splash" options={{ headerShown: false }} />
-        <Stack.Screen name="login" options={{ headerShown: false }} />
+        {/* Login screen will be added once authentication is ready */}
+        {/* <Stack.Screen name="login" options={{ headerShown: false }} /> */}
         <Stack.Screen name="camera" options={{ headerShown: false }} />
         <Stack.Screen name="result" />
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />

--- a/app/splash.tsx
+++ b/app/splash.tsx
@@ -4,8 +4,10 @@ import { router } from 'expo-router';
 
 export default function SplashScreen() {
   useEffect(() => {
+    // Bypass login for now. Navigate directly to the camera screen.
+    // TODO: change back to '/login' once authentication is implemented.
     const timer = setTimeout(() => {
-      router.replace('/login');
+      router.replace('/camera');
     }, 1500);
     return () => clearTimeout(timer);
   }, []);


### PR DESCRIPTION
## Summary
- start app by routing directly to camera screen
- comment out login screen from stack

## Testing
- `yarn lint` *(fails: unable to fetch yarn package due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68578880dd308326b3207d7269e26398