### PR TITLE
Fix EAS CLI setup

### DIFF
--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -36,6 +36,14 @@ jobs:
           eas --version
           which eas
 
+      - name: 🔄 Ensure latest EAS CLI
+        run: npm install -g eas-cli
+
+      - name: 🐛 Debug EAS CLI version (after reinstall)
+        run: |
+          eas --version
+          which eas
+
       - name: 📝 Log Build Message
         run: echo "🚀 EAS Build triggered from main branch - camera 기능 업데이트 포함"
 


### PR DESCRIPTION
## Summary
- reinstall EAS CLI in the workflow after yarn install

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68579d268b008326910950a44a5b9ccb