### PR TITLE
Implement splash permissions and bottom tabs

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -34,10 +34,17 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
-        name="explore"
+        name="camera"
         options={{
-          title: 'Explore',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
+          title: 'Camera',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="camera.fill" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="profile"
+        options={{
+          title: 'Profile',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="person.fill" color={color} />,
         }}
       />
     </Tabs>

--- a/app/(tabs)/camera.tsx
+++ b/app/(tabs)/camera.tsx
@@ -1,0 +1,1 @@
+export { default } from '../camera';

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,6 +1,8 @@
 import { Image } from "expo-image";
 import { Link } from "expo-router";
-import { Platform, StyleSheet } from "react-native";
+import * as ImagePicker from "expo-image-picker";
+import { Camera, useCameraPermissions } from "expo-camera";
+import { Button, Platform, StyleSheet } from "react-native";
 
 import { HelloWave } from "@/components/HelloWave";
 import ParallaxScrollView from "@/components/ParallaxScrollView";
@@ -8,6 +10,9 @@ import { ThemedText } from "@/components/ThemedText";
 import { ThemedView } from "@/components/ThemedView";
 
 export default function HomeScreen() {
+  const [cameraPermission, requestCameraPermission] = useCameraPermissions();
+  const [mediaPermission, requestMediaPermission] = ImagePicker.useMediaLibraryPermissions();
+
   return (
     <ParallaxScrollView
       headerBackgroundColor={{ light: "#A1CEDC", dark: "#1D3D47" }}
@@ -21,6 +26,18 @@ export default function HomeScreen() {
         <ThemedText type="title">Welcome🤗🤗🤗🤗!</ThemedText>
         <HelloWave />
       </ThemedView>
+      {cameraPermission && cameraPermission.status !== 'granted' && (
+        <Button
+          title="카메라 권한 없음: 카메라 권한 요청하러가기"
+          onPress={requestCameraPermission}
+        />
+      )}
+      {mediaPermission && mediaPermission.status !== 'granted' && (
+        <Button
+          title="앨범 권한이 없음: 앨범 권한 요청하러 가기"
+          onPress={requestMediaPermission}
+        />
+      )}
       <Link href="/camera" style={styles.link}>
         <ThemedText type="link">Open Camera</ThemedText>
       </Link>

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,0 +1,14 @@
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function ProfileScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>User Profile</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  text: { fontSize: 18 },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,7 +21,6 @@ export default function RootLayout() {
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack initialRouteName="splash">
         <Stack.Screen name="splash" options={{ headerShown: false }} />
-        <Stack.Screen name="login" options={{ headerShown: false }} />
         <Stack.Screen name="camera" options={{ headerShown: false }} />
         <Stack.Screen name="result" />
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />

--- a/app/splash.tsx
+++ b/app/splash.tsx
@@ -1,13 +1,21 @@
 import { useEffect } from 'react';
 import { Image, StyleSheet, View } from 'react-native';
 import { router } from 'expo-router';
+import { useCameraPermissions } from 'expo-camera';
+import * as ImagePicker from 'expo-image-picker';
 
 export default function SplashScreen() {
+  const [, requestCameraPermission] = useCameraPermissions();
+  const [, requestMediaPermission] = ImagePicker.useMediaLibraryPermissions();
+
   useEffect(() => {
-    const timer = setTimeout(() => {
-      router.replace('/login');
-    }, 1500);
-    return () => clearTimeout(timer);
+    (async () => {
+      await requestCameraPermission();
+      await requestMediaPermission();
+      setTimeout(() => {
+        router.replace('/(tabs)');
+      }, 500);
+    })();
   }, []);
 
   return (

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -18,6 +18,8 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'camera.fill': 'photo-camera',
+  'person.fill': 'person',
 } as IconMapping;
 
 /**

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "expo-font": "~13.3.1",
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.3.0",
+    "expo-image-picker": "~15.2.2",
     "expo-linking": "~7.1.5",
     "expo-router": "^5.1.0",
     "expo-splash-screen": "~0.30.9",


### PR DESCRIPTION
## Summary
- request camera and media permissions in splash screen
- show permission buttons on home when missing
- add camera and profile tabs to the navigator
- expose camera screen in tab stack
- extend icon mapping for camera and person icons
- include expo-image-picker

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e255034c83269b3754dcea2edba8