### PR TITLE
Implement result photo display and Supabase auth

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,14 +1,57 @@
-import { View, Text, StyleSheet } from 'react-native';
+import { useEffect, useState } from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+import * as AuthSession from 'expo-auth-session';
+import * as WebBrowser from 'expo-web-browser';
+import { Session } from '@supabase/supabase-js';
+
+import { supabase } from '@/supabase';
+
+WebBrowser.maybeCompleteAuthSession();
+
+type Provider = 'google' | 'kakao' | 'apple';
 
 export default function ProfileScreen() {
+  const [session, setSession] = useState<Session | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => setSession(data.session));
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session);
+    });
+    return () => {
+      listener.subscription.unsubscribe();
+    };
+  }, []);
+
+  const signIn = async (provider: Provider) => {
+    const redirectTo = AuthSession.makeRedirectUri();
+    const { error } = await supabase.auth.signInWithOAuth({ provider, options: { redirectTo } });
+    if (error) console.warn('OAuth error', error.message);
+  };
+
+  const signOut = async () => {
+    await supabase.auth.signOut();
+  };
+
+  if (!session) {
+    return (
+      <View style={styles.container}>
+        <Button title="Sign in with Google" onPress={() => signIn('google')} />
+        <Button title="Sign in with Kakao" onPress={() => signIn('kakao')} />
+        <Button title="Sign in with Apple" onPress={() => signIn('apple')} />
+      </View>
+    );
+  }
+
   return (
     <View style={styles.container}>
-      <Text style={styles.text}>User Profile</Text>
+      <Text style={styles.text}>Logged in as {session.user.email}</Text>
+      <Button title="Sign Out" onPress={signOut} />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 12 },
   text: { fontSize: 18 },
 });

--- a/app/camera.tsx
+++ b/app/camera.tsx
@@ -22,7 +22,10 @@ export default function CameraScreen() {
         body: JSON.stringify({ image: photo.base64 }),
       });
       const data = await response.json();
-      router.push({ pathname: "/result", params: { text: data?.text ?? "No result" } });
+      router.push({
+        pathname: "/result",
+        params: { text: data?.text ?? "No result", imageUri: photo.uri },
+      });
     } catch (e) {
       console.warn("Upload error:", e);
       Alert.alert("Error", "There was an error processing the image.");
@@ -57,7 +60,10 @@ export default function CameraScreen() {
         body: JSON.stringify({ image: asset.base64 }),
       });
       const data = await response.json();
-      router.push({ pathname: "/result", params: { text: data?.text ?? "No result" } });
+      router.push({
+        pathname: "/result",
+        params: { text: data?.text ?? "No result", imageUri: asset.uri },
+      });
     } catch (e) {
       console.warn("Upload error:", e);
       Alert.alert("Error", "There was an error processing the image.");

--- a/app/result.tsx
+++ b/app/result.tsx
@@ -1,9 +1,10 @@
 import { Animated, StyleSheet, View } from 'react-native';
 import { Stack, useLocalSearchParams } from 'expo-router';
+import { Image } from 'expo-image';
 import { useEffect, useRef } from 'react';
 
 export default function ResultScreen() {
-  const { text } = useLocalSearchParams<{ text: string }>();
+  const { text, imageUri } = useLocalSearchParams<{ text: string; imageUri?: string }>();
   const opacity = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
@@ -18,6 +19,7 @@ export default function ResultScreen() {
     <>
       <Stack.Screen options={{ title: 'Result' }} />
       <View style={styles.container}>
+        {imageUri && <Image source={{ uri: imageUri }} style={styles.image} />}
         <Animated.Text style={[styles.text, { opacity }]}>{text}</Animated.Text>
       </View>
     </>
@@ -26,5 +28,6 @@ export default function ResultScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  image: { width: 200, height: 200, marginBottom: 16, resizeMode: 'contain' },
   text: { fontSize: 24, textAlign: 'center' },
 });


### PR DESCRIPTION
## Summary
- pass captured image URI to result page
- show photo with API response
- add Supabase OAuth login on profile screen

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68588a78d4808326a7dddec50872d62a