### PR TITLE
Add image preview on result screen

### DIFF
--- a/app/camera.tsx
+++ b/app/camera.tsx
@@ -22,7 +22,10 @@ export default function CameraScreen() {
         body: JSON.stringify({ image: photo.base64 }),
       });
       const data = await response.json();
-      router.push({ pathname: "/result", params: { text: data?.text ?? "No result" } });
+      router.push({
+        pathname: "/result",
+        params: { text: data?.text ?? "No result", imageUri: photo.uri },
+      });
     } catch (e) {
       console.warn("Upload error:", e);
       Alert.alert("Error", "There was an error processing the image.");
@@ -57,7 +60,10 @@ export default function CameraScreen() {
         body: JSON.stringify({ image: asset.base64 }),
       });
       const data = await response.json();
-      router.push({ pathname: "/result", params: { text: data?.text ?? "No result" } });
+      router.push({
+        pathname: "/result",
+        params: { text: data?.text ?? "No result", imageUri: asset.uri },
+      });
     } catch (e) {
       console.warn("Upload error:", e);
       Alert.alert("Error", "There was an error processing the image.");

--- a/app/result.tsx
+++ b/app/result.tsx
@@ -1,9 +1,9 @@
-import { Animated, StyleSheet, View } from 'react-native';
+import { Animated, StyleSheet, View, Image } from 'react-native';
 import { Stack, useLocalSearchParams } from 'expo-router';
 import { useEffect, useRef } from 'react';
 
 export default function ResultScreen() {
-  const { text } = useLocalSearchParams<{ text: string }>();
+  const { text, imageUri } = useLocalSearchParams<{ text: string; imageUri?: string }>();
   const opacity = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
@@ -18,6 +18,9 @@ export default function ResultScreen() {
     <>
       <Stack.Screen options={{ title: 'Result' }} />
       <View style={styles.container}>
+        {imageUri ? (
+          <Image source={{ uri: imageUri }} style={styles.image} />
+        ) : null}
         <Animated.Text style={[styles.text, { opacity }]}>{text}</Animated.Text>
       </View>
     </>
@@ -26,5 +29,6 @@ export default function ResultScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  image: { width: 150, height: 150, marginBottom: 20, borderRadius: 8 },
   text: { fontSize: 24, textAlign: 'center' },
 });

--- a/app/splash.tsx
+++ b/app/splash.tsx
@@ -13,7 +13,7 @@ export default function SplashScreen() {
       await requestCameraPermission();
       await requestMediaPermission();
       setTimeout(() => {
-        router.replace("/result");
+        router.replace("/camera");
       }, 500);
     })();
   }, []);


### PR DESCRIPTION
## Summary
- navigate from splash to camera after permissions
- send selected image to result screen
- display small preview on result screen

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d42d2e3748326ba90cccced86c994