### PR TITLE
Fix reminder hook flow

### DIFF
--- a/app/settings/notification.tsx
+++ b/app/settings/notification.tsx
@@ -2,7 +2,6 @@ import { ThemedText } from "@/components/ThemedText";
 import { ThemedView } from "@/components/ThemedView";
 import { sendPushNotification, useNotifications } from "@/hooks/useNotifications";
 import { useLocationStore } from "@/store/useLocationStore";
-import { usePoetReminder } from "@/hooks/usePoetReminder";
 import { useState } from "react";
 import { Button, StyleSheet, View } from "react-native";
 
@@ -13,8 +12,7 @@ export default function NotificationScreen() {
   const location = useLocationStore((s) => s.location);
   const [isSending, setIsSending] = useState(false);
 
-  // Start location tracking and proximity notifications
-  usePoetReminder();
+  // Location tracking & notifications handled globally in RootLayout
 
   const handleSendNotification = async () => {
     if (!expoPushToken) {

--- a/hooks/usePoetReminder.ts
+++ b/hooks/usePoetReminder.ts
@@ -33,6 +33,12 @@ export function usePoetReminder() {
   const { history } = usePoetHistoryStore();
   const setLocation = useLocationStore((s) => s.setLocation);
   const notifiedRef = useRef<Set<string>>(new Set());
+  // keep latest history without re-subscribing to location updates
+  const historyRef = useRef(history);
+
+  useEffect(() => {
+    historyRef.current = history;
+  }, [history]);
 
   useEffect(() => {
     let subscriber: Location.LocationSubscription | null = null;
@@ -49,7 +55,7 @@ export function usePoetReminder() {
         },
         (loc) => {
           setLocation(loc);
-          history.forEach((poet) => {
+          historyRef.current.forEach((poet) => {
             if (notifiedRef.current.has(poet.id)) return;
             const d = getDistanceFromLatLonInMeters(
               loc.coords.latitude,
@@ -77,5 +83,5 @@ export function usePoetReminder() {
         subscriber.remove();
       }
     };
-  }, [history, setLocation]);
+  }, [setLocation]);
 }


### PR DESCRIPTION
## Summary
- avoid re-subscribing to location updates whenever history changes
- remove duplicate reminder hook call from notification screen

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68692969368483268c1a156e53a0eed6