### PR TITLE
Add permission handling and settings navigation

### DIFF
--- a/app/camera.tsx
+++ b/app/camera.tsx
@@ -1,5 +1,5 @@
 import { CameraView, useCameraPermissions } from "expo-camera";
-import { Button, StyleSheet, Text, View } from "react-native";
+import { Alert, Button, Linking, StyleSheet, Text, View } from "react-native";
 
 export default function CameraScreen() {
   const [permission, requestPermission] = useCameraPermissions();
@@ -12,7 +12,22 @@ export default function CameraScreen() {
     return (
       <View style={styles.container}>
         <Text style={{ textAlign: "center" }}>We need your permission to show the camera</Text>
-        <Button onPress={requestPermission} title="grant permission" />
+        <Button
+          onPress={async () => {
+            const result = await requestPermission();
+            if (!result.granted) {
+              Alert.alert(
+                "Permission Required",
+                "Camera access is needed to take photos",
+                [
+                  { text: "Open Settings", onPress: () => Linking.openSettings() },
+                  { text: "Cancel", style: "cancel" },
+                ]
+              );
+            }
+          }}
+          title="grant permission"
+        />
       </View>
     );
   }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -4,7 +4,7 @@ import * as ImagePicker from "expo-image-picker";
 import { router } from "expo-router";
 import { Images, Settings } from "lucide-react-native";
 import { useRef } from "react";
-import { Alert, StyleSheet, TouchableOpacity, View } from "react-native";
+import { Alert, Linking, StyleSheet, TouchableOpacity, View, Text } from "react-native";
 
 // TODO(minjaelee): 1:1의 비율로 (카메라와 앨범 모두)
 
@@ -16,10 +16,41 @@ export default function CameraScreen() {
     return <View />;
   }
 
+  if (!permission.granted) {
+    return (
+      <View style={styles.container}>
+        <TouchableOpacity
+          onPress={async () => {
+            const result = await requestPermission();
+            if (!result.granted) {
+              Alert.alert(
+                "Permission Required",
+                "Camera access is needed to take photos",
+                [
+                  { text: "Open Settings", onPress: () => Linking.openSettings() },
+                  { text: "Cancel", style: "cancel" },
+                ]
+              );
+            }
+          }}>
+          <View>
+            <Images color={Colors.grey[300]} size={20} />
+          </View>
+          <View>
+            <Text style={{ textAlign: "center", marginTop: 8 }}>Grant Permission</Text>
+          </View>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
   const openAlbum = async () => {
     const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
     if (status !== "granted") {
-      Alert.alert("Permission Denied", "Sorry, we need camera roll permissions to make this work!");
+      Alert.alert("Permission Denied", "Sorry, we need camera roll permissions to make this work!", [
+        { text: "Open Settings", onPress: () => Linking.openSettings() },
+        { text: "OK" },
+      ]);
       return;
     }
 

--- a/app/splash.tsx
+++ b/app/splash.tsx
@@ -1,5 +1,9 @@
 import { router } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
+import * as Camera from "expo-camera";
+import * as ImagePicker from "expo-image-picker";
+import * as Location from "expo-location";
+import * as Notifications from "expo-notifications";
 import { useEffect } from "react";
 import { ActivityIndicator, StyleSheet, View } from "react-native";
 
@@ -8,6 +12,15 @@ export default function CustomSplashScreen() {
     async function prepareAndNavigate() {
       // Keep the native splash screen visible until we are ready to navigate
       await SplashScreen.preventAutoHideAsync();
+
+      // Ask for all permissions the app might need
+      await Camera.requestCameraPermissionsAsync();
+      await ImagePicker.requestMediaLibraryPermissionsAsync();
+      await Location.requestForegroundPermissionsAsync();
+      const { status: notifStatus } = await Notifications.getPermissionsAsync();
+      if (notifStatus !== "granted") {
+        await Notifications.requestPermissionsAsync();
+      }
 
       // Perform any setup here, e.g., loading fonts, data, etc.
       // We'll just wait 1 second as requested.

--- a/hooks/useCurrentLocation.ts
+++ b/hooks/useCurrentLocation.ts
@@ -1,5 +1,6 @@
 import * as Location from "expo-location";
 import { useEffect, useState } from "react";
+import { Alert, Linking } from "react-native";
 
 export function useCurrentLocation() {
   const [location, setLocation] = useState<Location.LocationObject | null>(null);
@@ -11,6 +12,14 @@ export function useCurrentLocation() {
       const { status } = await Location.requestForegroundPermissionsAsync();
       if (status !== "granted") {
         setErrorMsg("Permission to access location was denied");
+        Alert.alert(
+          "Permission Denied",
+          "Location permission is required",
+          [
+            { text: "Open Settings", onPress: () => Linking.openSettings() },
+            { text: "OK" },
+          ]
+        );
         return;
       }
 

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -1,7 +1,7 @@
 import Constants from "expo-constants";
 import * as Notifications from "expo-notifications";
 import { useEffect, useRef, useState } from "react";
-import { Platform } from "react-native";
+import { Alert, Linking, Platform } from "react-native";
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -22,7 +22,14 @@ async function registerForPushNotificationsAsync() {
       finalStatus = status;
     }
     if (finalStatus !== "granted") {
-      alert("Failed to get push token for push notification!");
+      Alert.alert(
+        "Permission Denied",
+        "Notification permission is required",
+        [
+          { text: "Open Settings", onPress: () => Linking.openSettings() },
+          { text: "OK" },
+        ]
+      );
       return;
     }
     token = (

--- a/hooks/usePoetReminder.ts
+++ b/hooks/usePoetReminder.ts
@@ -1,6 +1,7 @@
 import * as Location from "expo-location";
 import * as Notifications from "expo-notifications";
 import { useEffect, useRef } from "react";
+import { Alert, Linking } from "react-native";
 import { useLocationStore } from "@/store/useLocationStore";
 import { usePoetHistoryStore } from "@/store/usePoetHistoryStore";
 
@@ -45,6 +46,14 @@ export function usePoetReminder() {
     (async () => {
       const { status } = await Location.requestForegroundPermissionsAsync();
       if (status !== "granted") {
+        Alert.alert(
+          "Permission Denied",
+          "Location permission is required for reminders",
+          [
+            { text: "Open Settings", onPress: () => Linking.openSettings() },
+            { text: "OK" },
+          ]
+        );
         return;
       }
 


### PR DESCRIPTION
## Summary
- request camera, media library, location and notification permissions on splash screen
- show camera permission request UI on main screen
- guide user to OS settings when album or camera permission denied
- alert on denied notification and location permissions in hooks

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc887f89c8326813f703c8a14945f