### PR TITLE
Implement subscription offerings cache

### DIFF
--- a/app/settings/plans.tsx
+++ b/app/settings/plans.tsx
@@ -1,11 +1,31 @@
 import { ThemedText } from "@/components/ThemedText";
 import { ThemedView } from "@/components/ThemedView";
-import { StyleSheet } from "react-native";
+import { StyleSheet, FlatList } from "react-native";
+import { useSubscriptionStore } from "@/store/useSubscriptionStore";
+import { useEffect } from "react";
 
 export default function PlansScreen() {
+  const { availablePlans, refreshSubscriptionData, isLoading } = useSubscriptionStore();
+
+  useEffect(() => {
+    refreshSubscriptionData().catch(console.error);
+  }, []);
+
   return (
     <ThemedView style={styles.container}>
-      <ThemedText type="title">Plans</ThemedText>
+      <FlatList
+        data={availablePlans}
+        keyExtractor={(item) => item.id}
+        refreshing={isLoading}
+        onRefresh={() => refreshSubscriptionData()}
+        renderItem={({ item }) => (
+          <ThemedView style={styles.item}>
+            <ThemedText type="subtitle">{item.title}</ThemedText>
+            <ThemedText>{item.price}</ThemedText>
+          </ThemedView>
+        )}
+        ListEmptyComponent={<ThemedText>No plans available</ThemedText>}
+      />
     </ThemedView>
   );
 }
@@ -13,7 +33,11 @@ export default function PlansScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
+    padding: 16,
+  },
+  item: {
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderColor: "#ccc",
   },
 });

--- a/services/revenueCatService.ts
+++ b/services/revenueCatService.ts
@@ -1,5 +1,6 @@
 import { REVENUECAT_API_KEY_ANDROID, REVENUECAT_API_KEY_IOS } from "@env";
 import { Platform } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import Purchases, {
   CustomerInfo,
   LOG_LEVEL,
@@ -8,9 +9,37 @@ import Purchases, {
   PurchasesPackage,
 } from "react-native-purchases";
 
+const OFFERINGS_CACHE_KEY = "@offerings_cache";
+const OFFERINGS_CACHE_TTL = 3600; // 1 hour
+
 export class RevenueCatService {
   private static instance: RevenueCatService;
   private initialized = false;
+
+  private async loadCachedOfferings(): Promise<PurchasesOffering | null> {
+    try {
+      const raw = await AsyncStorage.getItem(OFFERINGS_CACHE_KEY);
+      if (!raw) return null;
+      const cached = JSON.parse(raw) as { timestamp: number; data: PurchasesOffering | null };
+      if (Date.now() - cached.timestamp > OFFERINGS_CACHE_TTL * 1000) {
+        await AsyncStorage.removeItem(OFFERINGS_CACHE_KEY);
+        return null;
+      }
+      return cached.data;
+    } catch (error) {
+      console.warn('Failed to load offerings cache', error);
+      return null;
+    }
+  }
+
+  private async saveCachedOfferings(offerings: PurchasesOffering | null): Promise<void> {
+    try {
+      const data = { timestamp: Date.now(), data: offerings };
+      await AsyncStorage.setItem(OFFERINGS_CACHE_KEY, JSON.stringify(data));
+    } catch (error) {
+      console.warn('Failed to save offerings cache', error);
+    }
+  }
 
   static getInstance(): RevenueCatService {
     if (!RevenueCatService.instance) {
@@ -91,19 +120,36 @@ export class RevenueCatService {
   /**
    * Get available offerings (subscription plans)
    */
-  async getOfferings(): Promise<PurchasesOffering | null> {
+  async getOfferings(forceRefresh = false): Promise<PurchasesOffering | null> {
     try {
       if (!this.initialized) {
         console.warn("RevenueCat not initialized. Call initialize() first.");
         return null;
       }
 
+      if (!forceRefresh) {
+        const cached = await this.loadCachedOfferings();
+        if (cached) return cached;
+      }
+
       const offerings = await Purchases.getOfferings();
-      return offerings.current;
+      const current = offerings.current;
+      await this.saveCachedOfferings(current);
+      return current;
     } catch (error) {
       console.error("Failed to get offerings:", error);
       return null;
     }
+  }
+
+  /**
+   * Get single product information from cached offerings
+   */
+  async getProductInfo(identifier: string): Promise<PurchasesPackage | null> {
+    const offerings = await this.getOfferings();
+    if (!offerings) return null;
+    const pkg = offerings.availablePackages.find((p) => p.identifier === identifier);
+    return pkg || null;
   }
 
   /**

--- a/store/useSubscriptionStore.ts
+++ b/store/useSubscriptionStore.ts
@@ -101,12 +101,12 @@ export const useSubscriptionStore = create<SubscriptionStore>((set, get) => ({
       if (offerings?.availablePackages) {
         const plans: SubscriptionPlan[] = offerings.availablePackages.map((pkg) => ({
           id: pkg.identifier,
-          title: pkg.identifier, // Use identifier as title for now
-          description: `${pkg.packageType} subscription plan`, // Placeholder description
-          price: "TBD", // Price to be determined from store
+          title: pkg.storeProduct.title || pkg.identifier,
+          description: pkg.storeProduct.description || `${pkg.packageType} plan`,
+          price: pkg.storeProduct.priceString,
           duration: pkg.packageType,
           features: getFeaturesByPackageType(pkg.packageType),
-          isPopular: pkg.packageType === "MONTHLY", // You can customize this logic
+          isPopular: pkg.packageType === "MONTHLY",
         }));
         set({ availablePlans: plans });
       }


### PR DESCRIPTION
## Summary
- add RevenueCat offerings cache using AsyncStorage
- surface product details from cached offerings
- expose subscription plans in Plans screen
- display plan titles and prices in subscription store

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_687ce71dc7908326a64eb74ed4f116f2