### PR TITLE
Implement subscription state management

### DIFF
--- a/services/subscriptionService.ts
+++ b/services/subscriptionService.ts
@@ -1,0 +1,113 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import NetInfo from "@react-native-community/netinfo";
+import * as Notifications from "expo-notifications";
+import { supabase } from "../supabase";
+import type { SubscriptionStatus } from "../types/subscription";
+
+const STORAGE_KEY = "@subscription_status";
+const NOTI_KEY = "@subscription_renewal_noti";
+
+class SubscriptionService {
+  private async fetchRemoteStatus(): Promise<SubscriptionStatus | null> {
+    try {
+      const { data: { user }, error: authError } = await supabase.auth.getUser();
+      if (authError || !user) {
+        return null;
+      }
+      const { data, error } = await supabase
+        .from("users")
+        .select("subscription_type, subscription_expires_at")
+        .eq("id", user.id)
+        .single();
+      if (error || !data) {
+        return null;
+      }
+      const isActive = data.subscription_type === "premium" &&
+        (!data.subscription_expires_at || new Date(data.subscription_expires_at) > new Date());
+      const status: SubscriptionStatus = {
+        isActive,
+        expirationDate: data.subscription_expires_at || undefined,
+        productIdentifier: data.subscription_type,
+        willRenew: Boolean(data.subscription_expires_at),
+        periodType: data.subscription_type,
+      };
+      return status;
+    } catch (e) {
+      console.warn("[SubscriptionService] remote fetch failed", e);
+      return null;
+    }
+  }
+
+  private async getStoredStatus(): Promise<SubscriptionStatus | null> {
+    try {
+      const raw = await AsyncStorage.getItem(STORAGE_KEY);
+      return raw ? (JSON.parse(raw) as SubscriptionStatus) : null;
+    } catch (e) {
+      console.warn("[SubscriptionService] load stored status failed", e);
+      return null;
+    }
+  }
+
+  private async storeStatus(status: SubscriptionStatus): Promise<void> {
+    try {
+      await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(status));
+    } catch (e) {
+      console.warn("[SubscriptionService] store status failed", e);
+    }
+  }
+
+  async getStatus(forceRefresh = false): Promise<SubscriptionStatus> {
+    const net = await NetInfo.fetch();
+    if (!net.isConnected || !net.isInternetReachable) {
+      const cached = await this.getStoredStatus();
+      return cached || { isActive: false };
+    }
+
+    if (!forceRefresh) {
+      const cached = await this.getStoredStatus();
+      if (cached) {
+        return cached;
+      }
+    }
+
+    const remote = await this.fetchRemoteStatus();
+    if (remote) {
+      await this.storeStatus(remote);
+      return remote;
+    }
+    const fallback = await this.getStoredStatus();
+    return fallback || { isActive: false };
+  }
+
+  async scheduleRenewalNotification(expirationDate: string): Promise<void> {
+    try {
+      const triggerDate = new Date(expirationDate);
+      triggerDate.setDate(triggerDate.getDate() - 1);
+      if (triggerDate <= new Date()) return;
+      const id = await Notifications.scheduleNotificationAsync({
+        content: {
+          title: "구독 갱신 알림",
+          body: "구독이 곧 만료됩니다. 갱신을 진행해주세요.",
+        },
+        trigger: triggerDate,
+      });
+      await AsyncStorage.setItem(NOTI_KEY, id);
+    } catch (e) {
+      console.warn("[SubscriptionService] schedule notification failed", e);
+    }
+  }
+
+  async cancelRenewalNotification(): Promise<void> {
+    try {
+      const id = await AsyncStorage.getItem(NOTI_KEY);
+      if (id) {
+        await Notifications.cancelScheduledNotificationAsync(id);
+        await AsyncStorage.removeItem(NOTI_KEY);
+      }
+    } catch (e) {
+      console.warn("[SubscriptionService] cancel notification failed", e);
+    }
+  }
+}
+
+export default new SubscriptionService();

--- a/store/useSubscriptionStore.ts
+++ b/store/useSubscriptionStore.ts
@@ -1,4 +1,5 @@
 import RevenueCatService from "@/services/revenueCatService";
+import SubscriptionService from "@/services/subscriptionService";
 import { SubscriptionFeatures, SubscriptionPlan, SubscriptionStatus } from "@/types/subscription";
 import { CustomerInfo, PurchasesOffering, PurchasesPackage } from "react-native-purchases";
 import { create } from "zustand";
@@ -27,6 +28,7 @@ interface SubscriptionStore {
   refreshSubscriptionData: () => Promise<void>;
   purchasePackage: (packageToPurchase: PurchasesPackage) => Promise<boolean>;
   restorePurchases: () => Promise<boolean>;
+  checkSubscriptionStatus: () => Promise<void>;
   getSubscriptionFeatures: () => SubscriptionFeatures;
   hasFeature: (feature: keyof SubscriptionFeatures) => boolean;
   reset: () => void;
@@ -164,6 +166,26 @@ export const useSubscriptionStore = create<SubscriptionStore>((set, get) => ({
       const errorMessage = error instanceof Error ? error.message : "Failed to restore purchases";
       set({ error: errorMessage });
       return false;
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+
+  // Check subscription status from backend and schedule renewal notification
+  checkSubscriptionStatus: async () => {
+    try {
+      set({ isLoading: true, error: null });
+      const status = await SubscriptionService.getStatus();
+      set({ subscriptionStatus: status });
+
+      if (status.expirationDate) {
+        await SubscriptionService.scheduleRenewalNotification(status.expirationDate);
+      } else {
+        await SubscriptionService.cancelRenewalNotification();
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to check subscription";
+      set({ error: message });
     } finally {
       set({ isLoading: false });
     }


### PR DESCRIPTION
## Summary
- add a SubscriptionService for checking subscription status
- update SubscriptionStore to use new service and schedule renewal notifications

## Testing
- `yarn lint` *(fails: proxy response 403)*
- `yarn tsc -p tsconfig.json` *(fails: proxy response 403)*

------
https://chatgpt.com/codex/tasks/task_e_687e437858e08326a91274b5429839c0