### PR TITLE
Add subscription test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,13 @@ Join our community of developers creating universal apps.
 
 - [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
 - [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.
+# Subscription Tests
+
+Subscription 기능을 검증하려면 의존성을 설치한 후 아래 명령어를 실행합니다.
+
+```bash
+yarn test:subscription
+```
+
+`tests/subscription.test.ts`에서 RevenueCat과 구독 상태를 확인하는 예제 테스트를 제공합니다.
 # poetcam-app

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "test:subscription": "ts-node ./tests/subscription.test.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.56.0",

--- a/tests/subscription.test.ts
+++ b/tests/subscription.test.ts
@@ -1,0 +1,68 @@
+import RevenueCatService from "../services/revenueCatService";
+import SubscriptionService from "../services/subscriptionService";
+
+/**
+ * Subscription 기능을 종합적으로 테스트합니다.
+ * 실제 결제는 진행하지 않고 초기화 및 상태 조회만 확인합니다.
+ */
+export async function runSubscriptionTests() {
+  console.log("\uD83E\uDDEA Subscription 테스트 시작...");
+
+  try {
+    // 1. RevenueCat 초기화
+    console.log("1. RevenueCat 초기화...");
+    const initResult = await RevenueCatService.initialize();
+    console.log(`   \u2705 초기화: ${initResult ? "성공" : "실패"}`);
+    if (!initResult) {
+      throw new Error("RevenueCat 초기화 실패");
+    }
+
+    // 2. 구독 정보 조회
+    console.log("2. 구독 상태 조회...");
+    const status = await SubscriptionService.getStatus();
+    console.log(`   \u2705 활성화 여부: ${status.isActive}`);
+    if (status.expirationDate) {
+      console.log(`   \u23F0 만료일: ${status.expirationDate}`);
+    }
+
+    // 3. 제공 중인 플랜 조회
+    console.log("3. 구독 플랜 조회...");
+    const offerings = await RevenueCatService.getOfferings();
+    console.log(`   \u2705 플랜 수: ${offerings?.availablePackages.length || 0}`);
+
+    console.log("\uD83C\uDF89 모든 Subscription 테스트가 완료되었습니다!");
+    return true;
+  } catch (error) {
+    console.error("\u274C Subscription 테스트 실패:", error);
+    return false;
+  }
+}
+
+/**
+ * 개발 환경에서 구독 설정을 검증합니다.
+ */
+export async function validateSubscriptionSetup(): Promise<{
+  isValid: boolean;
+  issues: string[];
+}> {
+  const issues: string[] = [];
+  try {
+    if (!process.env.REVENUECAT_API_KEY_ANDROID && !process.env.REVENUECAT_API_KEY_IOS) {
+      issues.push("RevenueCat API 키가 설정되지 않음");
+    }
+    const status = await SubscriptionService.getStatus();
+    if (!status) {
+      issues.push("구독 상태 조회 실패");
+    }
+    return {
+      isValid: issues.length === 0,
+      issues,
+    };
+  } catch (error) {
+    issues.push(`구독 검증 중 오류 발생: ${error instanceof Error ? error.message : "Unknown"}`);
+    return {
+      isValid: false,
+      issues,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add manual subscription test script
- add subscription test script entry in `package.json`
- document how to run subscription test

## Testing
- `yarn lint` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.19.tgz)*
- `yarn test:subscription` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.19.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_687f7a604844832691a81562ca450ac0